### PR TITLE
translate tab items with both markups "*" as well as "-"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -582,16 +582,16 @@
       }
     },
     "@diplodoc/tabs-extension": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@diplodoc/tabs-extension/-/tabs-extension-2.0.7.tgz",
-      "integrity": "sha512-qvHvR9mEUoLu8I1N7iYH1yXjy2IMvDz79Ql42rwovDPzerds68GKyDedmnmLyooewS+5fm8vLlsGp7D/P/hAcQ=="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@diplodoc/tabs-extension/-/tabs-extension-2.0.9.tgz",
+      "integrity": "sha512-GYI+6t2PqVaCJFnB7Vd5/gy4Vm3ZVu7i0BaRwNPcz5m0nf8NXaEwMeaH8HuOKuFJjlbTEAB4xi9A/B3MNPBSfA=="
     },
     "@doc-tools/transform": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@doc-tools/transform/-/transform-3.8.0.tgz",
-      "integrity": "sha512-q/KIrg7s2Nys5oLYiqy3z/COGH2uawX6smY2pvTvgfXZOVFotZ/F3HJUwRok/EobyHoD8AqCpYoU74BAYxCEqw==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@doc-tools/transform/-/transform-3.8.2.tgz",
+      "integrity": "sha512-kCCrvBNbw3Qxj0XfsP7azhEGj5p9SYdTeylSoE5ag8ks8Rtrv/4CaIrwBXlecVahsNqO3Rwt8f3wgG80/zv1JQ==",
       "requires": {
-        "@diplodoc/tabs-extension": "^2.0.7",
+        "@diplodoc/tabs-extension": "^2.0.9",
         "chalk": "4.1.2",
         "get-root-node-polyfill": "1.0.0",
         "github-slugger": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -556,12 +556,12 @@
       "integrity": "sha512-PzjcMaqgRrqkBKUfF8A1abThOtQ+c1o5ma4d9bnrsfgmWtlScrr9O1VgBV5aeDPhm3LfhbdQSTDask9AS41rBA=="
     },
     "@diplodoc/markdown-it-markdown-renderer": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.14.1.tgz",
-      "integrity": "sha512-MlimTwiBApZgcI3Qqi6vfuv9qmi8AB8fBHA4KuRwJgVGzNuOr6A+DWZG/YbsYUFZ+XBqSZhie6eHbCBQDpX7yQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.14.2.tgz",
+      "integrity": "sha512-QYoPhPLLtg2wevs1VysHgML/eoH0NrKX4RYzYEsX5Ep2kUEWL7QI5AUYCSnb90NCFw4efD0U0qM9PWSXURUQUw==",
       "requires": {
         "@diplodoc/markdown-it-custom-renderer": "0.0.1",
-        "@doc-tools/transform": "^3.8.0",
+        "@doc-tools/transform": "^3.8.2",
         "markdown-it-sup": "^1.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@cospired/i18n-iso-languages": "^4.1.0",
     "@diplodoc/markdown-it-custom-renderer": "0.0.2",
-    "@diplodoc/markdown-it-markdown-renderer": "^0.14.1",
+    "@diplodoc/markdown-it-markdown-renderer": "^0.14.2",
     "@diplodoc/sentenizer": "0.0.0",
     "@doc-tools/transform": "^3.8.2",
     "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@diplodoc/markdown-it-custom-renderer": "0.0.2",
     "@diplodoc/markdown-it-markdown-renderer": "^0.14.1",
     "@diplodoc/sentenizer": "0.0.0",
-    "@doc-tools/transform": "^3.8.0",
+    "@doc-tools/transform": "^3.8.2",
     "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",
     "fast-xml-parser": "^4.1.3",
     "js-yaml": "^4.1.0",

--- a/src/__fixtures__/tabs.ts
+++ b/src/__fixtures__/tabs.ts
@@ -13,6 +13,14 @@ const markdown = `\
   Текст второго таба
 
 {% endlist %}
+
+{% list tabs %}
+
+* Первый Таб во второй таб секции
+
+  контент первого таба во второй таб секции
+
+{% endlist %}
 `;
 
 const skeleton = `\
@@ -30,6 +38,14 @@ const skeleton = `\
   %%%6%%%
 
 {% endlist %}
+
+{% list tabs %}
+
+* %%%7%%%
+
+  %%%8%%%
+
+{% endlist %}
 `;
 
 const translations = new Map<string, string>([
@@ -39,6 +55,8 @@ const translations = new Map<string, string>([
     ['4', 'content inside the list'],
     ['5', 'Second tab'],
     ['6', 'text of the second tab'],
+    ['7', 'First tab inside the second tab section'],
+    ['8', 'content of the first tab inside the second tab section'],
 ]);
 
 export {markdown, skeleton, translations};

--- a/src/markdown/__snapshots__/renderer.test.ts.snap
+++ b/src/markdown/__snapshots__/renderer.test.ts.snap
@@ -238,6 +238,15 @@ exports[`markdown rendering renders translated text instead of hashes, with tabs
   text of the second tab
 
 {% endlist %}
+
+
+{% list tabs %}
+
+* First tab inside the second tab section
+
+  content of the first tab inside the second tab section
+
+{% endlist %}
 "
 `;
 

--- a/src/skeleton/__snapshots__/renderer.test.ts.snap
+++ b/src/skeleton/__snapshots__/renderer.test.ts.snap
@@ -221,6 +221,15 @@ exports[`skeleton rendering renders hash instead of the content from markdown wi
   %%%6%%%
 
 {% endlist %}
+
+
+{% list tabs %}
+
+* %%%7%%%
+
+  %%%8%%%
+
+{% endlist %}
 "
 `;
 

--- a/src/xlf/__snapshots__/renderer.test.ts.snap
+++ b/src/xlf/__snapshots__/renderer.test.ts.snap
@@ -720,6 +720,12 @@ exports[`xlf rendering handles markdown with tabs syntax 1`] = `
       <trans-unit id=\\"6\\">
         <source>Текст второго таба</source>
       </trans-unit>
+      <trans-unit id=\\"7\\">
+        <source>Первый Таб во второй таб секции</source>
+      </trans-unit>
+      <trans-unit id=\\"8\\">
+        <source>контент первого таба во второй таб секции</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
fix: now we can translate tab items created with the "*" markup