### PR TITLE
feat(xlf/parser): render xlf inline as markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3031,6 +3031,14 @@
         "entities": "^2.0.0"
       },
       "dependencies": {
+        "domhandler": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+          "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
         "entities": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -3044,11 +3052,11 @@
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "requires": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       }
     },
     "domutils": {
@@ -3059,6 +3067,16 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+          "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        }
       }
     },
     "electron-to-chromium": {
@@ -4367,6 +4385,14 @@
         "entities": "^2.0.0"
       },
       "dependencies": {
+        "domhandler": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+          "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
         "entities": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@diplodoc/markdown-translation",
-  "version": "0.15.4",
+  "version": "1.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diplodoc/markdown-translation",
-  "version": "0.15.4",
+  "version": "1.0.0-beta.0",
   "description": "markdown translation utilities",
   "homepage": "https://github.com/diplodoc-platform/markdown-translation",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@doc-tools/transform": "^3.8.3",
     "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",
     "cheerio": "^1.0.0-rc.12",
+    "domhandler": "^5.0.3",
     "fast-xml-parser": "^4.1.3",
     "js-yaml": "^4.1.0",
     "markdown-it-meta": "0.0.1",

--- a/src/markdown/__snapshots__/renderer-inline.test.ts.snap
+++ b/src/markdown/__snapshots__/renderer-inline.test.ts.snap
@@ -1,3 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`inline: markdown rendering inline: renders translated markdown instead of hashes inside of the sentences with plain text 1`] = `"Sentence number one. Sentence number two."`;
+exports[`inline: markdown rendering inline: renders translated markdown instead of hashes inside of the sentences with bold. 1`] = `"Sentence number **one**. Sentence number **two**."`;
+
+exports[`inline: markdown rendering inline: renders translated markdown instead of hashes inside of the sentences with inline code. 1`] = `"Sentence number \`one\`. Sentence number \`two\`."`;
+
+exports[`inline: markdown rendering inline: renders translated markdown instead of hashes inside of the sentences with italics. 1`] = `"Sentence number *one*. Sentence number *two*."`;
+
+exports[`inline: markdown rendering inline: renders translated markdown instead of hashes inside of the sentences with links. 1`] = `"Sentence number one [link to file](file.md \\"title\\"). Sentence number two."`;
+
+exports[`inline: markdown rendering inline: renders translated markdown instead of hashes inside of the sentences with monospace. 1`] = `"Sentence number ##one##. Sentence number ##two##."`;
+
+exports[`inline: markdown rendering inline: renders translated markdown instead of hashes inside of the sentences with plain text. 1`] = `"Sentence number one. Sentence number two."`;
+
+exports[`inline: markdown rendering inline: renders translated markdown instead of hashes inside of the sentences with strikethrough. 1`] = `"Sentence number ~~one~~. Sentence number ~~two~~."`;
+
+exports[`inline: markdown rendering inline: renders translated markdown instead of hashes inside of the sentences with superscript. 1`] = `"Sentence number ^one^. Sentence number ^two^."`;

--- a/src/markdown/renderer-inline.test.ts
+++ b/src/markdown/renderer-inline.test.ts
@@ -1,12 +1,103 @@
 import {render, RenderParameters} from './renderer';
 
 describe('inline: markdown rendering', () => {
-    it('inline: renders translated markdown instead of hashes inside of the sentences with plain text', () => {
+    it('inline: renders translated markdown instead of hashes inside of the sentences with plain text.', () => {
         const parameters: RenderParameters = {
             skeleton: '%%%1%%% %%%2%%%',
             translations: new Map<string, string>([
                 ['1', 'Sentence number one.'],
                 ['2', 'Sentence number two.'],
+            ]),
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders translated markdown instead of hashes inside of the sentences with links.', () => {
+        const parameters: RenderParameters = {
+            skeleton: '%%%1%%% %%%2%%%',
+            translations: new Map<string, string>([
+                ['1', 'Sentence number one [link to file](file.md "title").'],
+                ['2', 'Sentence number two.'],
+            ]),
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders translated markdown instead of hashes inside of the sentences with bold.', () => {
+        const parameters: RenderParameters = {
+            skeleton: '%%%1%%% %%%2%%%',
+            translations: new Map<string, string>([
+                ['1', 'Sentence number **one**.'],
+                ['2', 'Sentence number **two**.'],
+            ]),
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders translated markdown instead of hashes inside of the sentences with italics.', () => {
+        const parameters: RenderParameters = {
+            skeleton: '%%%1%%% %%%2%%%',
+            translations: new Map<string, string>([
+                ['1', 'Sentence number *one*.'],
+                ['2', 'Sentence number *two*.'],
+            ]),
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders translated markdown instead of hashes inside of the sentences with strikethrough.', () => {
+        const parameters: RenderParameters = {
+            skeleton: '%%%1%%% %%%2%%%',
+            translations: new Map<string, string>([
+                ['1', 'Sentence number ~~one~~.'],
+                ['2', 'Sentence number ~~two~~.'],
+            ]),
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders translated markdown instead of hashes inside of the sentences with superscript.', () => {
+        const parameters: RenderParameters = {
+            skeleton: '%%%1%%% %%%2%%%',
+            translations: new Map<string, string>([
+                ['1', 'Sentence number ^one^.'],
+                ['2', 'Sentence number ^two^.'],
+            ]),
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders translated markdown instead of hashes inside of the sentences with monospace.', () => {
+        const parameters: RenderParameters = {
+            skeleton: '%%%1%%% %%%2%%%',
+            translations: new Map<string, string>([
+                ['1', 'Sentence number ##one##.'],
+                ['2', 'Sentence number ##two##.'],
+            ]),
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders translated markdown instead of hashes inside of the sentences with inline code.', () => {
+        const parameters: RenderParameters = {
+            skeleton: '%%%1%%% %%%2%%%',
+            translations: new Map<string, string>([
+                ['1', 'Sentence number `one`.'],
+                ['2', 'Sentence number `two`.'],
             ]),
         };
 

--- a/src/skeleton/__snapshots__/renderer-inline.test.ts.snap
+++ b/src/skeleton/__snapshots__/renderer-inline.test.ts.snap
@@ -1,3 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`inline: skeleton rendering inline: renders hash instead of the sentences with bold. 1`] = `"%%%1%%% %%%2%%%"`;
+
+exports[`inline: skeleton rendering inline: renders hash instead of the sentences with inline code. 1`] = `"%%%1%%% %%%2%%%"`;
+
+exports[`inline: skeleton rendering inline: renders hash instead of the sentences with italics. 1`] = `"%%%1%%% %%%2%%%"`;
+
+exports[`inline: skeleton rendering inline: renders hash instead of the sentences with links. 1`] = `"%%%1%%% %%%2%%%"`;
+
+exports[`inline: skeleton rendering inline: renders hash instead of the sentences with monospace. 1`] = `"%%%1%%% %%%2%%%"`;
+
 exports[`inline: skeleton rendering inline: renders hash instead of the sentences with plain text. 1`] = `"%%%1%%% %%%2%%%"`;
+
+exports[`inline: skeleton rendering inline: renders hash instead of the sentences with strikethrough. 1`] = `"%%%1%%% %%%2%%%"`;
+
+exports[`inline: skeleton rendering inline: renders hash instead of the sentences with superscript. 1`] = `"%%%1%%% %%%2%%%"`;

--- a/src/skeleton/handlers/index.ts
+++ b/src/skeleton/handlers/index.ts
@@ -1,4 +1,4 @@
-import {linkClose} from './link';
+// import {linkClose} from './link';
 import {imageClose} from './image';
 import {yfmFile} from './diplodoc/file';
 
@@ -8,7 +8,7 @@ function generate() {
 
 function handlers() {
     return {
-        link_close: linkClose,
+        // link_close: linkClose,
         image_close: imageClose,
         yfm_file: yfmFile,
     };

--- a/src/skeleton/renderer-inline.test.ts
+++ b/src/skeleton/renderer-inline.test.ts
@@ -9,4 +9,67 @@ describe('inline: skeleton rendering', () => {
         const rendered = render(parameters);
         expect(rendered).toMatchSnapshot();
     });
+
+    it('inline: renders hash instead of the sentences with links.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер один [ссылка](file.md "title"). Предложение номер два.',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders hash instead of the sentences with bold.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер **один**. Предложение номер **два**.',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders hash instead of the sentences with italics.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер *один*. Предложение номер *два*.',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders hash instead of the sentences with strikethrough.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер ~~один~~. Предложение номер ~~два~~.',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders hash instead of the sentences with superscript.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер ^один^. Предложение номер ^два^.',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders hash instead of the sentences with monospace.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер ##один##. Предложение номер ##два##.',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders hash instead of the sentences with inline code.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер `один`. Предложение номер `два`.',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
 });

--- a/src/xlf/__snapshots__/renderer-inline.test.ts.snap
+++ b/src/xlf/__snapshots__/renderer-inline.test.ts.snap
@@ -66,6 +66,28 @@ exports[`inline: xlf rendering inline: renders trans-unit for each sentence from
 "
 `;
 
+exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with links without titles. 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"text.md\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"text.skl.md\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"1\\">
+        <source>Предложение номер один <g ctype=\\"x-[-]\\">ссылка на файл</g><g ctype=\\"x-(-)\\"><x ctype=\\"x-link-href\\" equiv-text=\\"file.md\\" /></g>.</source>
+      </trans-unit>
+      <trans-unit id=\\"2\\">
+        <source>Предложение номер два.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"
+`;
+
 exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with links. 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">

--- a/src/xlf/__snapshots__/renderer-inline.test.ts.snap
+++ b/src/xlf/__snapshots__/renderer-inline.test.ts.snap
@@ -1,5 +1,115 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with bold. 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"text.md\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"text.skl.md\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"1\\">
+        <source>Предложение номер <g ctype=\\"x-**-**\\">один</g>.</source>
+      </trans-unit>
+      <trans-unit id=\\"2\\">
+        <source>Предложение номер <g ctype=\\"x-**-**\\">два</g>.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"
+`;
+
+exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with inline code. 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"text.md\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"text.skl.md\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"1\\">
+        <source>Предложение номер <g ctype=\\"x-\`-\`\\">один</g>.</source>
+      </trans-unit>
+      <trans-unit id=\\"2\\">
+        <source>Предложение номер <g ctype=\\"x-\`-\`\\">два</g>.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"
+`;
+
+exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with italics. 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"text.md\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"text.skl.md\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"1\\">
+        <source>Предложение номер <g ctype=\\"x-*-*\\">один</g>.</source>
+      </trans-unit>
+      <trans-unit id=\\"2\\">
+        <source>Предложение номер <g ctype=\\"x-*-*\\">два</g>.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"
+`;
+
+exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with links. 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"text.md\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"text.skl.md\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"1\\">
+        <source>Предложение номер один <g ctype=\\"x-[-]\\">ссылка на файл</g><g ctype=\\"x-(-)\\"><x ctype=\\"x-link-href\\" equiv-text=\\"file.md\\" /><g ctype=\\"x-&quot;-&quot;\\">title</g></g>.</source>
+      </trans-unit>
+      <trans-unit id=\\"2\\">
+        <source>Предложение номер два.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"
+`;
+
+exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with monospace. 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"text.md\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"text.skl.md\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"1\\">
+        <source>Предложение номер <g ctype=\\"x-##-##\\">один</g>.</source>
+      </trans-unit>
+      <trans-unit id=\\"2\\">
+        <source>Предложение номер <g ctype=\\"x-##-##\\">два</g>.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"
+`;
+
 exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with plain text. 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
@@ -15,6 +125,50 @@ exports[`inline: xlf rendering inline: renders trans-unit for each sentence from
       </trans-unit>
       <trans-unit id=\\"2\\">
         <source>Предложение номер два.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"
+`;
+
+exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with strikethrough. 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"text.md\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"text.skl.md\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"1\\">
+        <source>Предложение номер <g ctype=\\"x-~~-~~\\">один</g>.</source>
+      </trans-unit>
+      <trans-unit id=\\"2\\">
+        <source>Предложение номер <g ctype=\\"x-~~-~~\\">два</g>.</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"
+`;
+
+exports[`inline: xlf rendering inline: renders trans-unit for each sentence from paragraph with superscript. 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
+  <file original=\\"text.md\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
+    <header>
+      <skeleton>
+        <external-file href=\\"text.skl.md\\"></external-file>
+      </skeleton>
+    </header>
+    <body>
+      <trans-unit id=\\"1\\">
+        <source>Предложение номер <g ctype=\\"x-^-^\\">один</g>.</source>
+      </trans-unit>
+      <trans-unit id=\\"2\\">
+        <source>Предложение номер <g ctype=\\"x-^-^\\">два</g>.</source>
       </trans-unit>
     </body>
   </file>

--- a/src/xlf/generator/trans-unit.ts
+++ b/src/xlf/generator/trans-unit.ts
@@ -1,55 +1,45 @@
-import {XMLBuilder} from 'fast-xml-parser';
-
-const options = {format: true, ignoreAttributes: false};
-const builder = new XMLBuilder(options);
-
 export type TransUnitParameters = {
     indentation?: number;
     target?: string;
+    targetLangLocale?: string;
     source?: string;
+    sourceLangLocale?: string;
     id: number;
 };
 
-export type TransUnitData = {
-    'trans-unit': {
-        source?: XLFHasText;
-        target?: XLFHasText;
-    } & XLFHasID;
-};
+function generate(parameters: TransUnitParameters) {
+    const {source, sourceLangLocale, target, targetLangLocale, id, indentation = 0} = parameters;
 
-export type XLFHasText = {
-    '#text'?: string;
-};
-
-export type XLFHasID = {
-    '@_id'?: number;
-};
-
-function generate({source, target, id, indentation = 0}: TransUnitParameters) {
-    const data: TransUnitData = {
-        'trans-unit': {
-            '@_id': id,
-        },
-    };
+    let rendered = ' '.repeat(indentation + 2);
+    rendered += `<trans-unit id="${id}">`;
 
     if (source?.length) {
-        data['trans-unit'].source = {
-            '#text': source,
-        };
+        rendered += '\n';
+        rendered += ' '.repeat(indentation + 4);
+        rendered += `<source`;
+        if (sourceLangLocale?.length) {
+            rendered += ` xml:lang="${sourceLangLocale}"`;
+        }
+        rendered += '>';
+        rendered += `${source}</source>`;
     }
 
     if (target?.length) {
-        data['trans-unit'].target = {
-            '#text': target,
-        };
+        rendered += '\n';
+        rendered += ' '.repeat(indentation + 4);
+        rendered += `<target`;
+        if (targetLangLocale?.length) {
+            rendered += ` xml:lang="${targetLangLocale}"`;
+        }
+        rendered += '>';
+        rendered += `${target}</target>`;
     }
 
-    return builder
-        .build(data)
-        .split('\n')
-        .filter(Boolean)
-        .map((s: string) => ' '.repeat(indentation + 2) + s)
-        .join('\n');
+    rendered += '\n';
+    rendered += ' '.repeat(indentation + 2);
+    rendered += '</trans-unit>';
+
+    return rendered;
 }
 
 export {generate};

--- a/src/xlf/hooks/after-inline.ts
+++ b/src/xlf/hooks/after-inline.ts
@@ -1,8 +1,12 @@
+import MarkdownIt from 'markdown-it';
 import {MarkdownRenderer} from '@diplodoc/markdown-it-markdown-renderer';
 import {CustomRendererHookParameters} from '@diplodoc/markdown-it-custom-renderer';
-import {segmenter} from 'src/xlf/segmenter';
 
+import {segmenter} from 'src/xlf/segmenter';
+import {gtre, ltre, qtre, slre} from 'src/xlf/symbols';
 import {XLFRendererState} from 'src/xlf/state';
+
+const escapeHTML = new MarkdownIt().utils.escapeHtml;
 
 function afterInline(
     this: MarkdownRenderer<XLFRendererState>,
@@ -12,14 +16,16 @@ function afterInline(
         return '';
     }
 
-    const artifact = parameters.rendered.join('');
-    if (!artifact.length) {
+    let rendered = parameters.rendered.join('');
+    if (!rendered.length) {
         return '';
     }
 
-    const generated = segmenter(artifact, this.state);
+    rendered = escapeHTML(rendered);
+    rendered = rendered.replace(gtre, '>').replace(ltre, '<').replace(qtre, '"').replace(slre, '/');
+    rendered = segmenter(rendered, this.state);
 
-    parameters.rendered.splice(0, parameters.rendered.length, generated);
+    parameters.rendered.splice(0, parameters.rendered.length, rendered);
 
     return '';
 }

--- a/src/xlf/parser.test.ts
+++ b/src/xlf/parser.test.ts
@@ -129,4 +129,19 @@ describe('parses translation units', () => {
             expect(translation).toStrictEqual(text);
         }
     });
+
+    it('parses trans-units targets with g and x tags', () => {
+        const [open, close] = template.generate(templateParameters).template;
+
+        const unit = `\
+<trans-unit id="1">
+    <target>Sentence with <g ctype="x-[-]">link</g><g ctype="x-(-)"><x ctype="x-link-href" equiv-text="file.md" /><g ctype="x-&quot-&quot">title</g></g>.</target>
+</trans-unit>`;
+        const expected = 'Sentence with [link](file.md "title").';
+
+        const document = open + unit + close;
+
+        const translations = parseTranslations({xlf: document});
+        expect(translations.get(String(1))).toStrictEqual(expected);
+    });
 });

--- a/src/xlf/parser.ts
+++ b/src/xlf/parser.ts
@@ -1,5 +1,6 @@
 import {XMLValidator} from 'fast-xml-parser';
 import cheerio from 'cheerio';
+import {type Element, type Text} from 'domhandler';
 
 export type TranslationUnitsByID = Map<string, string>;
 
@@ -29,37 +30,98 @@ function parseTranslations(parameters: GetTranslationsParameters): TranslationUn
     const units = new Map<string, string>();
 
     let i = startID;
-    for (const target of translations) {
-        let text = '';
-        for (const child of target.children ?? []) {
-            if (child.type === 'text') {
-                text += child.data;
-            }
-        }
+    for (const target of translations.get()) {
+        const ref = {seq: []};
+        flattenDOMTree(target, ref);
 
-        units.set(String(i++), text);
+        const markdown = renderXLFIntoMarkdown(ref.seq);
+
+        units.set(String(i++), markdown);
     }
 
     return units;
 }
 
+// fallback: use source if target is absent
+function replaceSourceWithTarget(xlf: string) {
+    return xlf.replace(/<source>/gmu, '<target>').replace(/<\/source>/gmu, '</target>');
+}
+
+// extract all trans-units->target
 function findTargets(xlf: string) {
-    let success = true;
     const query = cheerio.load(xlf);
 
-    const translations = query('trans-unit').find('target');
+    const translations = query('trans-unit').children('target');
     if (translations.length === 0) {
-        success = false;
+        return {
+            success: false,
+            translations,
+        };
     }
 
     return {
         translations,
-        success,
+        success: true,
     };
 }
 
-function replaceSourceWithTarget(xlf: string) {
-    return xlf.replace(/<source>/gmu, '<target>').replace(/<\/source>/gmu, '</target>');
+// receive nodes in DFO
+function flattenDOMTree(node: Element | null, ref: {seq: Element[]}) {
+    if (!node) {
+        return;
+    }
+
+    const fst = node;
+    if (node.name === 'g') {
+        const [_, open] = node.attribs.ctype.split('-');
+        const openNode = {...node, attribs: {ctype: `x-${open}`}} as unknown as Element;
+
+        ref.seq.push(openNode);
+    } else {
+        ref.seq.push(node);
+    }
+
+    // eslint-disable-next-line no-param-reassign
+    node = node?.firstChild as Element;
+
+    while (node) {
+        flattenDOMTree(node, ref);
+        // eslint-disable-next-line no-param-reassign
+        node = node.nextSibling as Element;
+    }
+
+    if (fst && fst?.name === 'g') {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const [_, open, close] = fst.attribs.ctype.split('-');
+        const newNode = {...fst, attribs: {ctype: `x-${close}`}} as unknown as Element;
+
+        ref.seq.push(newNode);
+    }
+}
+
+// render dom nodes into markdown
+function renderXLFIntoMarkdown(nodes: (Element | Text)[]) {
+    let text = '';
+    for (const child of nodes) {
+        if (child?.type === 'text') {
+            text += child.data;
+            continue;
+        }
+
+        if (child.name === 'g') {
+            const [_, syntax] = child.attribs.ctype.split('-');
+            text += syntax;
+        }
+
+        if (child.name === 'x') {
+            if (child.attribs.ctype === 'x-link-href') {
+                text += child.attribs['equiv-text'];
+            }
+            text += ' ';
+        }
+    }
+
+    return text;
 }
 
 function validParameters(parameters: GetTranslationsParameters) {

--- a/src/xlf/renderer-inline.test.ts
+++ b/src/xlf/renderer-inline.test.ts
@@ -19,4 +19,138 @@ describe('inline: xlf rendering', () => {
         const rendered = render(parameters);
         expect(rendered).toMatchSnapshot();
     });
+
+    it('inline: renders trans-unit for each sentence from paragraph with links.', () => {
+        const parameters: RenderParameters = {
+            markdown:
+                'Предложение номер один [ссылка на файл](file.md "title"). Предложение номер два.',
+            source: {
+                language: 'ru',
+                locale: 'RU' as const,
+            },
+            target: {
+                language: 'en',
+                locale: 'US' as const,
+            },
+            markdownPath: 'text.md',
+            skeletonPath: 'text.skl.md',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders trans-unit for each sentence from paragraph with bold.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер **один**. Предложение номер **два**.',
+            source: {
+                language: 'ru',
+                locale: 'RU' as const,
+            },
+            target: {
+                language: 'en',
+                locale: 'US' as const,
+            },
+            markdownPath: 'text.md',
+            skeletonPath: 'text.skl.md',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders trans-unit for each sentence from paragraph with italics.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер *один*. Предложение номер *два*.',
+            source: {
+                language: 'ru',
+                locale: 'RU' as const,
+            },
+            target: {
+                language: 'en',
+                locale: 'US' as const,
+            },
+            markdownPath: 'text.md',
+            skeletonPath: 'text.skl.md',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders trans-unit for each sentence from paragraph with strikethrough.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер ~~один~~. Предложение номер ~~два~~.',
+            source: {
+                language: 'ru',
+                locale: 'RU' as const,
+            },
+            target: {
+                language: 'en',
+                locale: 'US' as const,
+            },
+            markdownPath: 'text.md',
+            skeletonPath: 'text.skl.md',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders trans-unit for each sentence from paragraph with superscript.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер ^один^. Предложение номер ^два^.',
+            source: {
+                language: 'ru',
+                locale: 'RU' as const,
+            },
+            target: {
+                language: 'en',
+                locale: 'US' as const,
+            },
+            markdownPath: 'text.md',
+            skeletonPath: 'text.skl.md',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders trans-unit for each sentence from paragraph with monospace.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер ##один##. Предложение номер ##два##.',
+            source: {
+                language: 'ru',
+                locale: 'RU' as const,
+            },
+            target: {
+                language: 'en',
+                locale: 'US' as const,
+            },
+            markdownPath: 'text.md',
+            skeletonPath: 'text.skl.md',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('inline: renders trans-unit for each sentence from paragraph with inline code.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер `один`. Предложение номер `два`.',
+            source: {
+                language: 'ru',
+                locale: 'RU' as const,
+            },
+            target: {
+                language: 'en',
+                locale: 'US' as const,
+            },
+            markdownPath: 'text.md',
+            skeletonPath: 'text.skl.md',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
 });

--- a/src/xlf/renderer-inline.test.ts
+++ b/src/xlf/renderer-inline.test.ts
@@ -40,6 +40,25 @@ describe('inline: xlf rendering', () => {
         expect(rendered).toMatchSnapshot();
     });
 
+    it('inline: renders trans-unit for each sentence from paragraph with links without titles.', () => {
+        const parameters: RenderParameters = {
+            markdown: 'Предложение номер один [ссылка на файл](file.md). Предложение номер два.',
+            source: {
+                language: 'ru',
+                locale: 'RU' as const,
+            },
+            target: {
+                language: 'en',
+                locale: 'US' as const,
+            },
+            markdownPath: 'text.md',
+            skeletonPath: 'text.skl.md',
+        };
+
+        const rendered = render(parameters);
+        expect(rendered).toMatchSnapshot();
+    });
+
     it('inline: renders trans-unit for each sentence from paragraph with bold.', () => {
         const parameters: RenderParameters = {
             markdown: 'Предложение номер **один**. Предложение номер **два**.',

--- a/src/xlf/rules/code-inline.ts
+++ b/src/xlf/rules/code-inline.ts
@@ -1,0 +1,19 @@
+import {CustomRenderer} from '@diplodoc/markdown-it-custom-renderer';
+import Renderer from 'markdown-it/lib/renderer';
+import Token from 'markdown-it/lib/token';
+
+import {XLFRendererState} from 'src/xlf/state';
+import {gt, lt, qt, sl} from 'src/xlf/symbols';
+
+const rules: Renderer.RenderRuleRecord = {
+    code_inline: codeInline,
+};
+
+function codeInline(this: CustomRenderer<XLFRendererState>, tokens: Token[], i: number) {
+    const {markup = '`', content} = tokens[i];
+
+    return `${lt}g ctype=${qt}x-${markup}-${markup}${qt}${gt}${content}${lt}${sl}g${gt}`;
+}
+
+export {rules};
+export default {rules};

--- a/src/xlf/rules/diplodoc/index.ts
+++ b/src/xlf/rules/diplodoc/index.ts
@@ -1,4 +1,7 @@
 import {yfmFile} from './file';
+import strikethrough from './strikethrough';
+import sup from './sup';
+import monospace from './monospace';
 
 export type DiplodocRulesState = {};
 
@@ -39,18 +42,12 @@ const rules = {
     td_open: alwaysEmptyString,
     td_close: alwaysEmptyString,
     table_close: alwaysEmptyString,
-    // sup
-    sup_open: alwaysEmptyString,
-    sup_close: alwaysEmptyString,
     // checkbox
     checkbox_open: alwaysEmptyString,
     checkbox_input: alwaysEmptyString,
     checkbox_label_open: alwaysEmptyString,
     checkbox_label_close: alwaysEmptyString,
     checkbox_close: alwaysEmptyString,
-    // monospace
-    monospace_open: alwaysEmptyString,
-    monospace_close: alwaysEmptyString,
     // yfmFile
     yfm_file: yfmFile,
     // include
@@ -78,9 +75,12 @@ const rules = {
     yfm_tr_close: alwaysEmptyString,
     yfm_td_open: alwaysEmptyString,
     yfm_td_close: alwaysEmptyString,
-    // strikethrough,
-    s_open: alwaysEmptyString,
-    s_close: alwaysEmptyString,
+    // strikethrough
+    ...strikethrough.rules,
+    // sup
+    ...sup.rules,
+    // monospace
+    ...monospace.rules,
 };
 
 export {rules, initState};

--- a/src/xlf/rules/diplodoc/monospace.ts
+++ b/src/xlf/rules/diplodoc/monospace.ts
@@ -1,0 +1,27 @@
+import {CustomRenderer} from '@diplodoc/markdown-it-custom-renderer';
+import Renderer from 'markdown-it/lib/renderer';
+import Token from 'markdown-it/lib/token';
+
+import {XLFRendererState} from 'src/xlf/state';
+import {gt, lt, qt, sl} from 'src/xlf/symbols';
+
+const rules: Renderer.RenderRuleRecord = {
+    monospace_open: monospaceOpen,
+    monospace_close: monospaceClose,
+};
+
+function monospaceOpen(this: CustomRenderer<XLFRendererState>, tokens: Token[], i: number) {
+    let {markup} = tokens[i];
+    if (!markup?.length) {
+        markup = '##';
+    }
+
+    return `${lt}g ctype=${qt}x-${markup}-${markup}${qt}${gt}`;
+}
+
+function monospaceClose(this: CustomRenderer<XLFRendererState>) {
+    return `${lt}${sl}g${gt}`;
+}
+
+export {rules};
+export default {rules};

--- a/src/xlf/rules/diplodoc/strikethrough.ts
+++ b/src/xlf/rules/diplodoc/strikethrough.ts
@@ -1,0 +1,27 @@
+import {CustomRenderer} from '@diplodoc/markdown-it-custom-renderer';
+import Renderer from 'markdown-it/lib/renderer';
+import Token from 'markdown-it/lib/token';
+
+import {XLFRendererState} from 'src/xlf/state';
+import {gt, lt, qt, sl} from 'src/xlf/symbols';
+
+const rules: Renderer.RenderRuleRecord = {
+    s_open: strikethroughOpen,
+    s_close: strikethroughClose,
+};
+
+function strikethroughOpen(this: CustomRenderer<XLFRendererState>, tokens: Token[], i: number) {
+    let {markup} = tokens[i];
+    if (!markup?.length) {
+        markup = '~~';
+    }
+
+    return `${lt}g ctype=${qt}x-${markup}-${markup}${qt}${gt}`;
+}
+
+function strikethroughClose(this: CustomRenderer<XLFRendererState>) {
+    return `${lt}${sl}g${gt}`;
+}
+
+export {rules};
+export default {rules};

--- a/src/xlf/rules/diplodoc/sup.ts
+++ b/src/xlf/rules/diplodoc/sup.ts
@@ -1,0 +1,27 @@
+import {CustomRenderer} from '@diplodoc/markdown-it-custom-renderer';
+import Renderer from 'markdown-it/lib/renderer';
+import Token from 'markdown-it/lib/token';
+
+import {XLFRendererState} from 'src/xlf/state';
+import {gt, lt, qt, sl} from 'src/xlf/symbols';
+
+const rules: Renderer.RenderRuleRecord = {
+    sup_open: superscriptOpen,
+    sup_close: superscriptClose,
+};
+
+function superscriptOpen(this: CustomRenderer<XLFRendererState>, tokens: Token[], i: number) {
+    let {markup} = tokens[i];
+    if (!markup?.length) {
+        markup = '^';
+    }
+
+    return `${lt}g ctype=${qt}x-${markup}-${markup}${qt}${gt}`;
+}
+
+function superscriptClose(this: CustomRenderer<XLFRendererState>) {
+    return `${lt}${sl}g${gt}`;
+}
+
+export {rules};
+export default {rules};

--- a/src/xlf/rules/index.ts
+++ b/src/xlf/rules/index.ts
@@ -1,6 +1,9 @@
 import linkRules, {linkOpen, linkClose, LinkRuleState} from './link';
 import imageRules, {image, imageClose, ImageRuleState} from './image';
 import diplodocRules, {DiplodocRulesState} from './diplodoc';
+import strong from './strong';
+import italics from './italics';
+import codeInline from './code-inline';
 
 export type XLFRulesState = LinkRuleState & ImageRuleState & DiplodocRulesState;
 
@@ -11,7 +14,6 @@ function generate() {
 // blocks(container and leaf) create group
 function rules() {
     return {
-        code_inline: () => '',
         code_block: () => '',
         fence: () => '',
         hardbreak: () => '',
@@ -26,10 +28,6 @@ function rules() {
         bullet_list_close: () => '',
         ordered_list_open: () => '',
         ordered_list_close: () => '',
-        strong_open: () => '',
-        strong_close: () => '',
-        em_open: () => '',
-        em_close: () => '',
         blockquote_open: () => '',
         blockquote_close: () => '',
         list_item_open: () => '',
@@ -38,7 +36,10 @@ function rules() {
         link_close: linkClose,
         image,
         image_close: imageClose,
+        ...strong.rules,
+        ...italics.rules,
         ...diplodocRules.rules,
+        ...codeInline.rules,
     };
 }
 

--- a/src/xlf/rules/italics.ts
+++ b/src/xlf/rules/italics.ts
@@ -1,0 +1,27 @@
+import {CustomRenderer} from '@diplodoc/markdown-it-custom-renderer';
+import Renderer from 'markdown-it/lib/renderer';
+import Token from 'markdown-it/lib/token';
+
+import {XLFRendererState} from 'src/xlf/state';
+import {gt, lt, qt, sl} from 'src/xlf/symbols';
+
+const rules: Renderer.RenderRuleRecord = {
+    em_open: italicsOpen,
+    em_close: italicsClose,
+};
+
+function italicsOpen(this: CustomRenderer<XLFRendererState>, tokens: Token[], i: number) {
+    let {markup} = tokens[i];
+    if (!markup?.length) {
+        markup = '*';
+    }
+
+    return `${lt}g ctype=${qt}x-${markup}-${markup}${qt}${gt}`;
+}
+
+function italicsClose(this: CustomRenderer<XLFRendererState>) {
+    return `${lt}${sl}g${gt}`;
+}
+
+export {rules};
+export default {rules};

--- a/src/xlf/rules/link.ts
+++ b/src/xlf/rules/link.ts
@@ -1,9 +1,8 @@
 import {CustomRenderer} from '@diplodoc/markdown-it-custom-renderer';
 import Token from 'markdown-it/lib/token';
 
-import {segmenter} from 'src/xlf/segmenter';
-
 import {XLFRendererState} from 'src/xlf/state';
+import {gt, lt, qt, sl} from 'src/xlf/symbols';
 
 export type LinkRuleState = {
     link: {
@@ -22,7 +21,7 @@ function initState() {
 function linkOpen(this: CustomRenderer<XLFRendererState>, tokens: Token[], i: number) {
     this.state.link.pending.push(tokens[i]);
 
-    return '';
+    return `${lt}g ctype=${qt}x-[-]${qt}${gt}`;
 }
 
 function linkClose(this: CustomRenderer<XLFRendererState>) {
@@ -31,15 +30,23 @@ function linkClose(this: CustomRenderer<XLFRendererState>) {
         throw new Error('failed to render trans-unit from link');
     }
 
+    let rendered = `${lt}${sl}g${gt}${lt}g ctype=${qt}x-(-)${qt}${gt}`;
+
+    const href = token.attrGet('href');
+    if (href?.length) {
+        rendered += `${lt}x ctype=${qt}x-link-href${qt} equiv-text=${qt}${href}${qt} ${sl}${gt}`;
+    }
+
     const title = token.attrGet('title');
     if (!title?.length) {
         this.state.link.pending.push(token);
-        return '';
+
+        return rendered;
     }
 
-    let rendered = '';
+    rendered += `${lt}g ctype=${qt}x-"-"${qt}${gt}${title}${lt}${sl}g${gt}`;
 
-    rendered += segmenter(title, this.state);
+    rendered += `${lt}${sl}g${gt}`;
 
     return rendered;
 }

--- a/src/xlf/rules/link.ts
+++ b/src/xlf/rules/link.ts
@@ -40,11 +40,9 @@ function linkClose(this: CustomRenderer<XLFRendererState>) {
     const title = token.attrGet('title');
     if (!title?.length) {
         this.state.link.pending.push(token);
-
-        return rendered;
+    } else {
+        rendered += `${lt}g ctype=${qt}x-"-"${qt}${gt}${title}${lt}${sl}g${gt}`;
     }
-
-    rendered += `${lt}g ctype=${qt}x-"-"${qt}${gt}${title}${lt}${sl}g${gt}`;
 
     rendered += `${lt}${sl}g${gt}`;
 

--- a/src/xlf/rules/strong.ts
+++ b/src/xlf/rules/strong.ts
@@ -1,0 +1,27 @@
+import {CustomRenderer} from '@diplodoc/markdown-it-custom-renderer';
+import Renderer from 'markdown-it/lib/renderer';
+import Token from 'markdown-it/lib/token';
+
+import {XLFRendererState} from 'src/xlf/state';
+import {gt, lt, qt, sl} from 'src/xlf/symbols';
+
+const rules: Renderer.RenderRuleRecord = {
+    strong_open: strongOpen,
+    strong_close: strongClose,
+};
+
+function strongOpen(this: CustomRenderer<XLFRendererState>, tokens: Token[], i: number) {
+    let {markup} = tokens[i];
+    if (!markup?.length) {
+        markup = '**';
+    }
+
+    return `${lt}g ctype=${qt}x-${markup}-${markup}${qt}${gt}`;
+}
+
+function strongClose(this: CustomRenderer<XLFRendererState>) {
+    return `${lt}${sl}g${gt}`;
+}
+
+export {rules};
+export default {rules};

--- a/src/xlf/symbols.ts
+++ b/src/xlf/symbols.ts
@@ -1,0 +1,18 @@
+import crypto from 'crypto';
+
+const gt = crypto.randomUUID();
+const lt = crypto.randomUUID();
+const sl = crypto.randomUUID();
+const qt = crypto.randomUUID();
+
+// eslint-disable-next-line security/detect-non-literal-regexp
+const gtre = new RegExp(`${gt}`, 'gmu');
+// eslint-disable-next-line security/detect-non-literal-regexp
+const ltre = new RegExp(`${lt}`, 'gmu');
+// eslint-disable-next-line security/detect-non-literal-regexp
+const qtre = new RegExp(`${qt}`, 'gmu');
+// eslint-disable-next-line security/detect-non-literal-regexp
+const slre = new RegExp(`${sl}`, 'gmu');
+
+export {lt, gt, sl, qt, gtre, ltre, qtre, slre};
+export default {lt, gt, sl, qt, gtre, ltre, qtre, slre};


### PR DESCRIPTION
improved segmentation for syntax:

- links
- bold
- italics
- strikethrough
- superscript
- monospace
- inline code