### PR TITLE
api/compose: add useSource option

### DIFF
--- a/src/api/compose.test.ts
+++ b/src/api/compose.test.ts
@@ -36,6 +36,7 @@ describe('validates parameters', () => {
         const parameters = {
             skeleton: '',
             xlf: xlf,
+            useSource: true,
         };
 
         compose(parameters);
@@ -45,18 +46,15 @@ describe('validates parameters', () => {
         const invalidXLF = {
             xlf: '',
         };
-
         const invalidSkeleton = {
             xlf: xlf,
         };
-
-        const invalidBoth = {};
-
         const invalidLang = {xlf, skeleton: '', lang: 'xx'};
+        const invalidUseSource = {xlf, useSource: null};
 
         expect(() => compose(invalidSkeleton as ComposeParameters)).toThrow();
         expect(() => compose(invalidXLF as ComposeParameters)).toThrow();
-        expect(() => compose(invalidBoth as ComposeParameters)).toThrow();
         expect(() => compose(invalidLang as ComposeParameters)).toThrow();
+        expect(() => compose(invalidUseSource as unknown as ComposeParameters)).toThrow();
     });
 });

--- a/src/api/compose.ts
+++ b/src/api/compose.ts
@@ -4,6 +4,7 @@ import markdown from 'src/markdown';
 export type ComposeParameters = {
     skeleton: string;
     xlf: string;
+    useSource?: boolean;
 } & markdown.renderer.DiplodocParameters;
 
 function compose(parameters: ComposeParameters) {
@@ -19,6 +20,7 @@ function compose(parameters: ComposeParameters) {
 
 function validParameters(parameters: ComposeParameters) {
     const conditions = [
+        parameters.useSource === undefined || typeof parameters.useSource === 'boolean',
         parameters.skeleton !== undefined,
         parameters.xlf !== undefined,
         xlf.parser.validParameters(parameters),


### PR DESCRIPTION
allows to use source of the trans-unit while composing markdown

`useSource` `boolean` flag:
https://github.com/diplodoc-platform/markdown-translation/blob/bd9e5419b7fe7f41f515cc3a3bd018b206af520b/src/api/compose.ts#L4-L8