### PR TITLE
wrap inline code syntax in g tags

### DIFF
--- a/src/xlf/parser/__snapshots__/parser.test.ts.snap
+++ b/src/xlf/parser/__snapshots__/parser.test.ts.snap
@@ -127,7 +127,7 @@ Array [
 ]
 `;
 
-exports[`parses translation units with <g> and <x> tags parses code wrapped in <x> tag 1`] = `
+exports[`parses translation units with <g> and <x> tags parses code wrapped in <g> tag 1`] = `
 Array [
   Array [
     Object {
@@ -140,9 +140,20 @@ Array [
       "type": "text",
     },
     Object {
-      "data": "x",
-      "equivText": "\`один\`",
-      "nodeType": "self-closing",
+      "data": "g",
+      "equivText": "\`",
+      "nodeType": "open",
+      "syntax": "code",
+      "type": "tag",
+    },
+    Object {
+      "data": "один",
+      "type": "text",
+    },
+    Object {
+      "data": "g",
+      "equivText": "\`",
+      "nodeType": "close",
       "syntax": "code",
       "type": "tag",
     },

--- a/src/xlf/parser/parser.test.ts
+++ b/src/xlf/parser/parser.test.ts
@@ -136,9 +136,9 @@ describe('parses translation units with <g> and <x> tags', () => {
         expect(translations).toMatchSnapshot();
     });
 
-    it('parses code wrapped in <x> tag', () => {
+    it('parses code wrapped in <g> tag', () => {
         const units = [
-            {id: 1, target: 'Предложение номер <x ctype="x-code" equiv-text="`один`" />.'},
+            {id: 1, target: 'Предложение номер <g ctype="x-code" equiv-text="`">один</g>.'},
         ];
         const xlf = generateXLF(units);
         const translations = parseTranslations({xlf});

--- a/src/xlf/renderer/md-xlf/__snapshots__/renderer-inline.test.ts.snap
+++ b/src/xlf/renderer/md-xlf/__snapshots__/renderer-inline.test.ts.snap
@@ -22,7 +22,7 @@ exports[`renders xlf from markdown renders autolink wrapped in <g> and <x> tags 
 "
 `;
 
-exports[`renders xlf from markdown renders code wrapped in <x> tag 1`] = `
+exports[`renders xlf from markdown renders code wrapped in <g> tag 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <xliff xmlns=\\"urn:oasis:names:tc:xliff:document:1.2\\" version=\\"1.2\\">
   <file original=\\"text.md\\" source-language=\\"ru-RU\\" target-language=\\"en-US\\" datatype=\\"markdown\\">
@@ -33,10 +33,10 @@ exports[`renders xlf from markdown renders code wrapped in <x> tag 1`] = `
     </header>
     <body>
       <trans-unit id=\\"1\\">
-        <source>Предложение номер <x ctype=\\"x-code\\" equiv-text=\\"\`один\`\\" />.</source>
+        <source>Предложение номер <g ctype=\\"x-code\\" equiv-text=\\"\`\\">один</g>.</source>
       </trans-unit>
       <trans-unit id=\\"2\\">
-        <source>Предложение номер <x ctype=\\"x-code\\" equiv-text=\\"\`два\`\\" />.</source>
+        <source>Предложение номер <g ctype=\\"x-code\\" equiv-text=\\"\`\\">два</g>.</source>
       </trans-unit>
     </body>
   </file>

--- a/src/xlf/renderer/md-xlf/renderer-inline.test.ts
+++ b/src/xlf/renderer/md-xlf/renderer-inline.test.ts
@@ -84,7 +84,7 @@ describe('renders xlf from markdown', () => {
         expect(rendered).toMatchSnapshot();
     });
 
-    it('renders code wrapped in <x> tag', () => {
+    it('renders code wrapped in <g> tag', () => {
         const parameters: RenderParameters = {
             ...baseRendererParameters,
             markdown: 'Предложение номер `один`. Предложение номер `два`.',

--- a/src/xlf/renderer/md-xlf/rules/code-inline.ts
+++ b/src/xlf/renderer/md-xlf/rules/code-inline.ts
@@ -3,7 +3,7 @@ import Renderer from 'markdown-it/lib/renderer';
 import Token from 'markdown-it/lib/token';
 
 import {XLFRendererState} from 'src/xlf/renderer/md-xlf/state';
-import {generateOpenG, generateCloseG} from 'src/xlf/generator';
+import {generateCloseG, generateOpenG} from 'src/xlf/generator';
 
 const codeInline: Renderer.RenderRuleRecord = {
     code_inline: codeInlineRule,

--- a/src/xlf/renderer/md-xlf/rules/code-inline.ts
+++ b/src/xlf/renderer/md-xlf/rules/code-inline.ts
@@ -3,16 +3,25 @@ import Renderer from 'markdown-it/lib/renderer';
 import Token from 'markdown-it/lib/token';
 
 import {XLFRendererState} from 'src/xlf/renderer/md-xlf/state';
-import {generateX} from 'src/xlf/generator';
+import {generateOpenG, generateCloseG} from 'src/xlf/generator';
 
 const codeInline: Renderer.RenderRuleRecord = {
     code_inline: codeInlineRule,
 };
 
 function codeInlineRule(this: CustomRenderer<XLFRendererState>, tokens: Token[], i: number) {
-    const {markup, content, tag} = tokens[i];
+    const {markup, content, tag, type} = tokens[i];
+    if (!markup?.length) {
+        throw new Error(`markup missing for token: ${type}`);
+    }
 
-    return generateX({ctype: tag, equivText: `${markup}${content}${markup}`});
+    let rendered = '';
+
+    rendered += generateOpenG({ctype: tag, equivText: markup});
+    rendered += content;
+    rendered += generateCloseG();
+
+    return rendered;
 }
 
 export {codeInline};

--- a/src/xlf/renderer/xlf-md/__snapshots__/renderer-inline.test.ts.snap
+++ b/src/xlf/renderer/xlf-md/__snapshots__/renderer-inline.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`renders xlf to markdown renders autolink wrapped in <x> tags 1`] = `"Предложение номер один <https://www.google.com>."`;
 
-exports[`renders xlf to markdown renders code wrapped in <x> tag 1`] = `"Предложение номер \`один\`."`;
+exports[`renders xlf to markdown renders code wrapped in <g> tag 1`] = `"Предложение номер \`один\`."`;
 
 exports[`renders xlf to markdown renders em wrapped in <g> tags 1`] = `"Предложение номер *один*."`;
 

--- a/src/xlf/renderer/xlf-md/renderer-inline.test.ts
+++ b/src/xlf/renderer/xlf-md/renderer-inline.test.ts
@@ -179,7 +179,6 @@ describe('renders xlf to markdown', () => {
 
         const rendered = renderer.render(tokens);
         expect(rendered).toMatchSnapshot();
-        console.log(rendered);
     });
 
     it('renders link wrapped in <g> and <x> tags', () => {

--- a/src/xlf/renderer/xlf-md/renderer-inline.test.ts
+++ b/src/xlf/renderer/xlf-md/renderer-inline.test.ts
@@ -153,17 +153,25 @@ describe('renders xlf to markdown', () => {
         expect(rendered).toMatchSnapshot();
     });
 
-    it('renders code wrapped in <x> tag', () => {
+    it('renders code wrapped in <g> tag', () => {
         const renderer = new XLFMDRenderer();
         const tokens: Array<XLFToken> = [
             {type: 'tag', data: 'target', nodeType: 'open'},
             {type: 'text', data: 'Предложение номер '},
             {
                 type: 'tag',
-                data: 'x',
+                data: 'g',
                 nodeType: 'open',
                 syntax: 'code',
-                equivText: '`один`',
+                equivText: '`',
+            },
+            {type: 'text', data: 'один'},
+            {
+                type: 'tag',
+                data: 'g',
+                nodeType: 'close',
+                syntax: 'code',
+                equivText: '`',
             },
             {type: 'text', data: '.'},
             {type: 'tag', data: 'target', nodeType: 'close'},
@@ -171,6 +179,7 @@ describe('renders xlf to markdown', () => {
 
         const rendered = renderer.render(tokens);
         expect(rendered).toMatchSnapshot();
+        console.log(rendered);
     });
 
     it('renders link wrapped in <g> and <x> tags', () => {


### PR DESCRIPTION
wrap inline code syntax in `<g>` tags instead of hiding it from translators with `<x>` tag.