### PR TITLE
fix: extract page-constructor blocks schema-aware instead of as raw markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "ts-dedent": "^2.2.0",
         "uri-js": "^4.4.1",
         "xml-formatter": "^3.6.1",
-        "xml-parser-xo": "^4.1.1"
+        "xml-parser-xo": "^4.1.1",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.24.7",
@@ -11808,10 +11809,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@cospired/i18n-iso-languages": "^4.1.0",
+        "@diplodoc/ajv": "^0.4.1",
         "@diplodoc/directive": "^0.3.6",
         "@diplodoc/sentenizer": "^0.0.11",
         "@diplodoc/transform": "^4.77.5",
@@ -743,6 +744,21 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "node_modules/@diplodoc/ajv": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@diplodoc/ajv/-/ajv-0.4.1.tgz",
+      "integrity": "sha512-gd9vgWtQ0fXW/TURtGE8VGl/2qaH0KP3z3rW5OjefKcL2voVcqOIOHNKpg7muU7zmeYh8RqoDjrr5PD3j4jKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "diplodoc-ajv-build-schemas": "scripts/build-schemas.js"
+      },
+      "engines": {
+        "npm": ">=11.5.1"
       }
     },
     "node_modules/@diplodoc/cut-extension": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "ts-dedent": "^2.2.0",
     "uri-js": "^4.4.1",
     "xml-formatter": "^3.6.1",
-    "xml-parser-xo": "^4.1.1"
+    "xml-parser-xo": "^4.1.1",
+    "yaml": "^2.9.0"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@cospired/i18n-iso-languages": "^4.1.0",
+    "@diplodoc/ajv": "^0.4.1",
     "@diplodoc/directive": "^0.3.6",
     "@diplodoc/sentenizer": "^0.0.11",
     "@diplodoc/transform": "^4.77.5",

--- a/src/json/translate.ts
+++ b/src/json/translate.ts
@@ -10,7 +10,7 @@ import {replace, token} from 'src/utils';
 
 type Schema = 'md' | 'text';
 
-function genCode(ontranslate: (text: string, schema: Schema) => string) {
+export function genCode(ontranslate: (text: string, schema: Schema) => string) {
     return function (cxt: KeywordCxt) {
         const {gen, data, it, schema} = cxt;
         const {parentData, parentDataProperty} = it;

--- a/src/skeleton/__snapshots__/index.spec.ts.snap
+++ b/src/skeleton/__snapshots__/index.spec.ts.snap
@@ -239,3 +239,30 @@ exports[`inline: skeleton rendering > inline: renders hash instead of the senten
 exports[`inline: skeleton rendering > inline: renders hash instead of the sentences with variable image syntax. 1`] = `"%%%0%%% %%%1%%%"`;
 
 exports[`inline: skeleton rendering > inline: renders hash instead of the sentences with video syntax. 1`] = `"%%%0%%% %%%1%%% @[youtube](https://youtu.be/rJz4OaURJ6U)"`;
+
+exports[`page-constructor: yaml-aware extraction > does not expose yaml structure in units 1`] = `
+Array [
+  "<source xml:space=\\"preserve\\">Текст до блока.</source>",
+  "<source xml:space=\\"preserve\\">Наш продукт</source>",
+  "<source xml:space=\\"preserve\\">Описание продукта</source>",
+  "<source xml:space=\\"preserve\\">Начать</source>",
+  "<source xml:space=\\"preserve\\">Текст после блока.</source>",
+]
+`;
+
+exports[`page-constructor: yaml-aware extraction > replaces translatable values with hashes and keeps yaml structure 1`] = `
+"%%%0%%%
+
+::: page-constructor
+blocks:
+  - type: 'header-block'
+    title: '%%%1%%%'
+    description: '%%%2%%%'
+    buttons:
+      - text: '%%%3%%%'
+        url: '/start'
+:::
+
+%%%4%%%
+"
+`;

--- a/src/skeleton/index.spec.ts
+++ b/src/skeleton/index.spec.ts
@@ -492,6 +492,8 @@ blocks:
 Текст после блока.
 `;
 
+    // The first test pays the one-time page-constructor schema compilation,
+    // which needs a longer timeout under coverage instrumentation.
     it('replaces translatable values with hashes and keeps yaml structure', () => {
         const rendered = render(block);
 
@@ -502,7 +504,7 @@ blocks:
         expect(rendered).not.toContain('Наш продукт');
         expect(rendered).not.toContain('Начать');
         expect(rendered).toMatchSnapshot();
-    });
+    }, 30000);
 
     it('does not expose yaml structure in units', () => {
         const hashed = hash();

--- a/src/skeleton/index.spec.ts
+++ b/src/skeleton/index.spec.ts
@@ -552,6 +552,55 @@ blocks:
         expect(rendered).toContain('Второй абзац');
     });
 
+    it('anchors values that are substrings of other values', () => {
+        const collision = `::: page-constructor
+blocks:
+  - type: 'header-block'
+    description: 'Наш продукт Про'
+    title: 'Наш продукт'
+:::
+`;
+        const rendered = render(collision);
+
+        expect(rendered).toMatch(/description: '%%%\d+%%%'\n/);
+        expect(rendered).toMatch(/title: '%%%\d+%%%'\n/);
+        expect(rendered).not.toContain('Наш продукт');
+    });
+
+    it('does not match values inside non-translatable scalars', () => {
+        const tricky = `::: page-constructor
+blocks:
+  - type: 'header-block'
+    background:
+      image:
+        src: '/images/Начать'
+    title: 'Начать'
+:::
+`;
+        const rendered = render(tricky);
+
+        expect(rendered).toContain("src: '/images/Начать'");
+        expect(rendered).toMatch(/title: '%%%\d+%%%'\n/);
+    });
+
+    it('anchors repeated values to consecutive occurrences', () => {
+        const repeated = `::: page-constructor
+blocks:
+  - type: 'card-layout-block'
+    title: 'Карточки'
+    children:
+      - type: 'basic-card'
+        text: 'Подробнее'
+      - type: 'basic-card'
+        text: 'Подробнее'
+:::
+`;
+        const rendered = render(repeated);
+
+        expect(rendered).not.toContain('Подробнее');
+        expect(rendered.match(/text: '%%%\d+%%%'/g)).toHaveLength(2);
+    });
+
     it('does not touch page-constructor examples inside code fences', () => {
         const fenced =
             "```yaml\n::: page-constructor\nblocks:\n  - type: 'header-block'\n    title: 'Заголовок'\n:::\n```\n";

--- a/src/skeleton/index.spec.ts
+++ b/src/skeleton/index.spec.ts
@@ -1,4 +1,4 @@
-import {describe, expect, it} from 'vitest';
+import {beforeAll, describe, expect, it} from 'vitest';
 
 import {compose, extract} from 'src/api';
 import {hash} from 'src/hash';
@@ -477,6 +477,13 @@ describe('image: translatable attributes (title and alt)', () => {
 });
 
 describe('page-constructor: yaml-aware extraction', () => {
+    // The one-time schema compilation is a setup cost, not a test cost:
+    // warmed up here so every test below runs within the default timeout
+    // even under coverage instrumentation.
+    beforeAll(() => {
+        render('::: page-constructor\nblocks: []\n:::\n');
+    }, 30000);
+
     const block = `Текст до блока.
 
 ::: page-constructor
@@ -492,8 +499,6 @@ blocks:
 Текст после блока.
 `;
 
-    // The first test pays the one-time page-constructor schema compilation,
-    // which needs a longer timeout under coverage instrumentation.
     it('replaces translatable values with hashes and keeps yaml structure', () => {
         const rendered = render(block);
 
@@ -504,7 +509,7 @@ blocks:
         expect(rendered).not.toContain('Наш продукт');
         expect(rendered).not.toContain('Начать');
         expect(rendered).toMatchSnapshot();
-    }, 30000);
+    });
 
     it('does not expose yaml structure in units', () => {
         const hashed = hash();

--- a/src/skeleton/index.spec.ts
+++ b/src/skeleton/index.spec.ts
@@ -601,6 +601,38 @@ blocks:
         expect(rendered.match(/text: '%%%\d+%%%'/g)).toHaveLength(2);
     });
 
+    it('does not inject translations into scalars ending with the value', () => {
+        const tricky = `::: page-constructor
+blocks:
+  - type: 'header-block'
+    background:
+      image:
+        src: '/img/promo-Начать'
+    title: 'Начать'
+:::
+`;
+        const rendered = render(tricky);
+
+        expect(rendered).toContain("src: '/img/promo-Начать'");
+        expect(rendered).toMatch(/title: '%%%\d+%%%'\n/);
+    });
+
+    it('does not translate equal text in non-translatable fields', () => {
+        const twins = `::: page-constructor
+blocks:
+  - type: 'filter-block'
+    tags:
+      - 'Начать'
+    title: 'Начать'
+:::
+`;
+        const rendered = render(twins);
+
+        // The filter-block schema marks only the title as translatable.
+        expect(rendered).toContain("- 'Начать'");
+        expect(rendered).toMatch(/title: '%%%\d+%%%'\n/);
+    });
+
     it('does not touch page-constructor examples inside code fences', () => {
         const fenced =
             "```yaml\n::: page-constructor\nblocks:\n  - type: 'header-block'\n    title: 'Заголовок'\n:::\n```\n";

--- a/src/skeleton/index.spec.ts
+++ b/src/skeleton/index.spec.ts
@@ -1,5 +1,8 @@
 import {describe, expect, it} from 'vitest';
 
+import {compose, extract} from 'src/api';
+import {hash} from 'src/hash';
+
 import {skeleton} from '.';
 
 function render(content: string) {
@@ -470,5 +473,98 @@ describe('image: translatable attributes (title and alt)', () => {
 
     it('renders standalone SVG with title and inline via markdown-it-attrs', () => {
         expect(render('![alt](test.svg){title="New Title" inline=true}')).toMatchSnapshot();
+    });
+});
+
+describe('page-constructor: yaml-aware extraction', () => {
+    const block = `Текст до блока.
+
+::: page-constructor
+blocks:
+  - type: 'header-block'
+    title: 'Наш продукт'
+    description: 'Описание продукта'
+    buttons:
+      - text: 'Начать'
+        url: '/start'
+:::
+
+Текст после блока.
+`;
+
+    it('replaces translatable values with hashes and keeps yaml structure', () => {
+        const rendered = render(block);
+
+        expect(rendered).toContain("type: 'header-block'");
+        expect(rendered).toContain("url: '/start'");
+        expect(rendered).toContain("title: '%%%");
+        expect(rendered).toContain("description: '%%%");
+        expect(rendered).not.toContain('Наш продукт');
+        expect(rendered).not.toContain('Начать');
+        expect(rendered).toMatchSnapshot();
+    });
+
+    it('does not expose yaml structure in units', () => {
+        const hashed = hash();
+        skeleton(block, {compact: true}, hashed);
+
+        const leaking = hashed.segments.filter(
+            (unit) => unit.includes(':::') || unit.includes('type:') || unit.includes('url:'),
+        );
+
+        expect(leaking).toEqual([]);
+        expect(hashed.segments).toMatchSnapshot();
+    });
+
+    it('keeps a block with broken yaml as is', () => {
+        const broken = `::: page-constructor
+blocks:
+  - title: 'Заголовок
+   bad: [indentation
+:::
+`;
+        expect(render(broken)).toBe(broken);
+    });
+
+    it('extracts folded scalars and keeps literal scalars untranslated', () => {
+        const multiline = `::: page-constructor
+blocks:
+  - type: 'header-block'
+    title: 'Заголовок'
+    description: >-
+      Первая строка
+      вторая строка
+    text: |
+      Первый абзац
+
+      Второй абзац
+:::
+`;
+        const rendered = render(multiline);
+
+        expect(rendered).toContain("title: '%%%");
+        // The folded scalar value is a single line, so it is matched
+        // across the source lines and translated.
+        expect(rendered).not.toContain('Первая строка');
+        // The literal scalar value contains newlines and cannot be
+        // matched verbatim, so it stays as is.
+        expect(rendered).toContain('Первый абзац');
+        expect(rendered).toContain('Второй абзац');
+    });
+
+    it('does not touch page-constructor examples inside code fences', () => {
+        const fenced =
+            "```yaml\n::: page-constructor\nblocks:\n  - type: 'header-block'\n    title: 'Заголовок'\n:::\n```\n";
+        expect(render(fenced)).toBe(fenced);
+    });
+
+    it('roundtrips through extract and compose', () => {
+        const {units, skeleton: skl} = extract(block, {
+            compact: true,
+            source: {language: 'ru', locale: 'RU'},
+            target: {language: 'en', locale: 'US'},
+        });
+
+        expect(compose(skl, units, {useSource: true})).toBe(block);
     });
 });

--- a/src/skeleton/index.ts
+++ b/src/skeleton/index.ts
@@ -26,6 +26,7 @@ import {noTranslate} from 'src/directives/no-translate';
 
 import term from './plugins/term';
 import includes from './plugins/includes';
+import {pageConstructor} from './plugins/page-constructor';
 import {hooks} from './hooks';
 import {rules} from './rules';
 
@@ -49,6 +50,7 @@ export function skeleton(markdown: string, options: SkeletonOptions = {}, hash: 
 
     // diplodoc plugins
     md.use(noTranslate(), diplodocOptions);
+    md.use(pageConstructor(), diplodocOptions);
     md.use(meta, diplodocOptions);
     md.use(includes, diplodocOptions);
     md.use(notes, diplodocOptions);

--- a/src/skeleton/plugins/page-constructor.ts
+++ b/src/skeleton/plugins/page-constructor.ts
@@ -1,0 +1,26 @@
+import type MarkdownIt from 'markdown-it';
+import type StateBlock from 'markdown-it/lib/rules_block/state_block';
+import type {ContainerDirectiveParams} from '@diplodoc/directive';
+
+import {directiveParser, registerContainerDirective} from '@diplodoc/directive';
+
+export function pageConstructor(): MarkdownIt.PluginSimple {
+    return (md) => {
+        md.use(directiveParser());
+
+        registerContainerDirective(
+            md,
+            'page-constructor',
+            (state: StateBlock, params: ContainerDirectiveParams) => {
+                const token = state.push('page_constructor', '', 0);
+
+                if (params.content) {
+                    token.content = params.content.raw;
+                    token.map = [params.content.startLine, params.content.endLine];
+                }
+
+                return true;
+            },
+        );
+    };
+}

--- a/src/skeleton/rules/index.ts
+++ b/src/skeleton/rules/index.ts
@@ -9,6 +9,7 @@ import {code} from './code';
 import {html} from './html';
 import {list} from './list';
 import {noTranslate} from './no-translate';
+import {pageConstructor} from './page-constructor';
 
 export const rules: Renderer.RenderRuleRecord = {
     ...text,
@@ -20,4 +21,5 @@ export const rules: Renderer.RenderRuleRecord = {
     ...html,
     ...list,
     ...noTranslate,
+    ...pageConstructor,
 };

--- a/src/skeleton/rules/page-constructor.ts
+++ b/src/skeleton/rules/page-constructor.ts
@@ -25,6 +25,10 @@ function getValidator() {
             strict: false,
             allErrors: true,
             $data: true,
+            // Skipping codegen optimization compiles the large schema ~2.5x
+            // faster; the validator runs once per block, so its own speed
+            // does not matter.
+            code: {optimize: false},
         });
 
         ajv.addKeyword({

--- a/src/skeleton/rules/page-constructor.ts
+++ b/src/skeleton/rules/page-constructor.ts
@@ -4,16 +4,16 @@ import type {CustomRenderer} from 'src/renderer';
 import type {Consumer} from 'src/consumer';
 
 import Ajv from 'ajv';
-import {load} from 'js-yaml';
+import {isScalar, parseDocument} from 'yaml';
 import {pageConstructorSchemaJson} from '@diplodoc/ajv';
 
-import {genCode} from 'src/json/translate';
 import {token} from 'src/utils';
 import {Liquid} from 'src/skeleton/liquid';
 
 // The validator is compiled once (the schema is large), so the collected
-// translatable strings are exchanged through this module-level buffer.
-let collected: string[] = [];
+// translatable paths are exchanged through this module-level buffer.
+// Keyed by instance path: anyOf branches may visit the same node twice.
+let collected = new Map<string, string>();
 let validator: ValidateFunction | null = null;
 
 function getValidator() {
@@ -30,17 +30,18 @@ function getValidator() {
         ajv.addKeyword({
             keyword: 'translate',
             type: ['string', 'object', 'array'],
-            code: genCode((text) => {
-                if (/^%%%\d+%%%$/.test(text)) {
-                    return text;
+            validate: function (
+                _schema: unknown,
+                value: unknown,
+                _parent?: unknown,
+                ctx?: {instancePath: string},
+            ) {
+                if (typeof value === 'string' && value.trim() && ctx) {
+                    collected.set(ctx.instancePath, value);
                 }
 
-                collected.push(text);
-
-                // Mark the value as processed to guard against repeated
-                // evaluation of the same data node (anyOf/oneOf branches).
-                return `%%%${collected.length - 1}%%%`;
-            }),
+                return true;
+            },
         });
 
         validator = ajv.compile(pageConstructorSchemaJson);
@@ -51,99 +52,44 @@ function getValidator() {
 
 type Anchor = {
     at: number;
+    end: number;
     text: string;
 };
 
-/**
- * A claimed occurrence must look like a whole YAML scalar, not a fragment
- * of another value: on its line it may only be preceded by a key separator,
- * a list dash or the line start (plus an opening quote and indentation).
- */
-function isScalarStart(yaml: string, index: number): boolean {
-    let i = index - 1;
-    if (yaml[i] === "'" || yaml[i] === '"') {
-        i--;
-    }
-    while (i >= 0 && (yaml[i] === ' ' || yaml[i] === '\t')) {
-        i--;
-    }
-
-    return i < 0 || yaml[i] === ':' || yaml[i] === '-' || yaml[i] === '\n';
+function unescapePointer(segment: string): string {
+    return segment.replace(/~1/g, '/').replace(/~0/g, '~');
 }
 
 /**
- * The scalar counterpart of `isScalarStart`: after the occurrence (and an
- * optional closing quote) only a line break, a flow terminator or a comment
- * may follow. Rejects occurrences that are prefixes of longer values.
+ * Resolves collected instance paths into exact character ranges of the
+ * scalar nodes inside the yaml source. Position-based addressing cannot
+ * confuse a value with an equal or overlapping text in another field.
+ * Aliased nodes resolve into their anchor and are translated once.
  */
-function isScalarEnd(yaml: string, index: number): boolean {
-    let i = index;
-    if (yaml[i] === "'" || yaml[i] === '"') {
-        i++;
-    }
-    while (i < yaml.length && (yaml[i] === ' ' || yaml[i] === '\t')) {
-        i++;
-    }
+function resolveAnchors(
+    doc: ReturnType<typeof parseDocument>,
+    paths: Map<string, string>,
+): Anchor[] {
+    const seen = new Set<number>();
+    const anchors: Anchor[] = [];
 
-    return i >= yaml.length || '\n\r,]}#'.includes(yaml[i]);
-}
-
-/**
- * Finds the first occurrence of the value that is not inside an already
- * claimed range and looks like a whole scalar. Returns -1 when the value
- * has no verbatim occurrence (folded scalars, escaped quoting).
- */
-function claimOccurrence(yaml: string, text: string, claimed: [number, number][]): number {
-    let from = 0;
-    while (from <= yaml.length - text.length) {
-        const at = yaml.indexOf(text, from);
-        if (at === -1) {
-            return -1;
-        }
-        from = at + 1;
-
-        const end = at + text.length;
-        if (claimed.some(([start, stop]) => at < stop && end > start)) {
-            continue;
-        }
-        if (!isScalarStart(yaml, at) || !isScalarEnd(yaml, end)) {
+    for (const [pointer, text] of paths) {
+        const path = pointer.split('/').slice(1).map(unescapePointer);
+        const node = doc.getIn(path, true);
+        if (!isScalar(node) || node.value !== text || !node.range) {
             continue;
         }
 
-        return at;
-    }
-
-    return -1;
-}
-
-/**
- * Assigns every value its own occurrence in the block. Longer values claim
- * first, so a value that is a substring of another one (title: 'Product'
- * next to description: 'Product Pro') cannot steal the longer value's
- * position and corrupt it. Repeated values claim consecutive occurrences.
- */
-function claimAnchors(yaml: string, strings: string[]): {anchored: Anchor[]; loose: string[]} {
-    const claimed: [number, number][] = [];
-    const anchored: Anchor[] = [];
-    const loose: string[] = [];
-
-    const byLength = strings
-        .map((text, index) => ({text, index}))
-        .sort((a, b) => b.text.length - a.text.length || a.index - b.index);
-
-    for (const {text} of byLength) {
-        const at = claimOccurrence(yaml, text, claimed);
-        if (at === -1) {
-            loose.push(text);
-        } else {
-            claimed.push([at, at + text.length]);
-            anchored.push({at, text});
+        const [at, end] = node.range;
+        if (seen.has(at)) {
+            continue;
         }
+        seen.add(at);
+
+        anchors.push({at, end, text});
     }
 
-    anchored.sort((a, b) => a.at - b.at);
-
-    return {anchored, loose};
+    return anchors.sort((a, b) => a.at - b.at);
 }
 
 function processBlock(consumer: Consumer, yaml: string, map: Token['map']) {
@@ -151,41 +97,34 @@ function processBlock(consumer: Consumer, yaml: string, map: Token['map']) {
         return;
     }
 
-    let data: unknown;
-    try {
-        data = load(yaml);
-    } catch {
+    const doc = parseDocument(yaml);
+    if (doc.errors.length) {
         // Broken YAML is left in the skeleton as is.
         return;
     }
 
+    const data = doc.toJS();
     if (!data || typeof data !== 'object') {
         return;
     }
 
-    collected = [];
+    collected = new Map();
     try {
-        getValidator()(data as object);
+        getValidator()(data);
     } catch {
         // Best effort: values collected before the failure are still processed.
     }
 
-    const strings = collected;
-    collected = [];
+    const paths = collected;
+    collected = new Map();
 
-    const {anchored, loose} = claimAnchors(
-        yaml,
-        strings.filter((text) => text.trim() && !text.includes('\n')),
-    );
-
-    // Anchored values are processed in their textual order (the consumer
-    // matches strictly forward), each within the window of its own line,
-    // so the consumer cannot match a fragment of a neighboring value.
-    // The token map points at the block content, so line offsets inside
-    // the yaml translate directly into document lines.
-    let line = map ? map[0] : 0;
+    // Anchors are processed in their textual order (the consumer matches
+    // strictly forward), each within the window of its own lines, so the
+    // consumer cannot cross into neighboring scalars. The token map points
+    // at the block content, so yaml offsets translate into document lines.
+    let line = 0;
     let scanned = 0;
-    for (const {at, text} of anchored) {
+    for (const {at, end, text} of resolveAnchors(doc, paths)) {
         while (scanned < at) {
             if (yaml[scanned] === '\n') {
                 line++;
@@ -193,21 +132,21 @@ function processBlock(consumer: Consumer, yaml: string, map: Token['map']) {
             scanned++;
         }
 
-        try {
-            consumer.process(token('text', {content: text}), map ? [line, line] : map);
-        } catch {
-            // The value was not found in the source block. It stays untranslated.
+        let endLine = line;
+        for (let i = at; i < end && i < yaml.length; i++) {
+            if (yaml[i] === '\n') {
+                endLine++;
+            }
         }
-    }
 
-    // Values without a verbatim occurrence (folded scalars) are matched
-    // last across the whole block, best effort: the consumer cursor is
-    // already past the anchored values, so only trailing ones can match.
-    for (const text of loose) {
         try {
-            consumer.process(token('text', {content: text}), map);
+            consumer.process(
+                token('text', {content: text}),
+                map ? [map[0] + line, map[0] + endLine] : map,
+            );
         } catch {
-            // The value was not found in the source block. It stays untranslated.
+            // The value cannot be matched in the source block (escaped
+            // quoting, literal block scalars). It stays untranslated.
         }
     }
 }

--- a/src/skeleton/rules/page-constructor.ts
+++ b/src/skeleton/rules/page-constructor.ts
@@ -1,0 +1,106 @@
+import type Renderer from 'markdown-it/lib/renderer';
+import type {ValidateFunction} from 'ajv';
+import type {CustomRenderer} from 'src/renderer';
+import type {Consumer} from 'src/consumer';
+
+import Ajv from 'ajv';
+import {load} from 'js-yaml';
+import {pageConstructorSchemaJson} from '@diplodoc/ajv';
+
+import {genCode} from 'src/json/translate';
+import {token} from 'src/utils';
+import {Liquid} from 'src/skeleton/liquid';
+
+// The validator is compiled once (the schema is large), so the collected
+// translatable strings are exchanged through this module-level buffer.
+let collected: string[] = [];
+let validator: ValidateFunction | null = null;
+
+function getValidator() {
+    if (!validator) {
+        const ajv = new Ajv({
+            strictSchema: false,
+            validateSchema: false,
+            validateFormats: false,
+            strict: false,
+            allErrors: true,
+            $data: true,
+        });
+
+        ajv.addKeyword({
+            keyword: 'translate',
+            type: ['string', 'object', 'array'],
+            code: genCode((text) => {
+                if (text.match(/^((-\s)?\s*%%%\d+%%%\s*)+$/gm)) {
+                    return text;
+                }
+
+                collected.push(text);
+
+                // Mark the value as processed to guard against repeated
+                // evaluation of the same data node (anyOf/oneOf branches).
+                return `%%%${collected.length - 1}%%%`;
+            }),
+        });
+
+        validator = ajv.compile(pageConstructorSchemaJson);
+    }
+
+    return validator;
+}
+
+export const pageConstructor: Renderer.RenderRuleRecord = {
+    page_constructor: function (this: CustomRenderer<Consumer>, tokens: Token[], idx) {
+        const {content, map} = tokens[idx];
+        const yaml = Liquid.unescape(content || '');
+
+        if (!yaml.trim()) {
+            return '';
+        }
+
+        let data: unknown;
+        try {
+            data = load(yaml);
+        } catch {
+            // Broken YAML is left in the skeleton as is.
+            return '';
+        }
+
+        if (!data || typeof data !== 'object') {
+            return '';
+        }
+
+        collected = [];
+        try {
+            getValidator()(data as object);
+        } catch {
+            // Best effort: values collected before the failure are still processed.
+        }
+
+        const strings = collected;
+        collected = [];
+
+        // The schema walks data in its own order, while the consumer
+        // matches strictly forward. Sort values by their position in
+        // the block to keep the cursor monotonic. Values without a
+        // verbatim occurrence (folded scalars) are matched last.
+        const positioned = strings
+            .filter((text) => !text.includes('\n'))
+            .map((text) => {
+                const at = yaml.indexOf(text);
+                return [at === -1 ? Infinity : at, text] as [number, string];
+            })
+            .sort((a, b) => a[0] - b[0]);
+
+        for (const [, text] of positioned) {
+            try {
+                this.state.process(token('text', {content: text}), map);
+            } catch {
+                // The value was not found in the source block
+                // (quoting, escaping). It stays untranslated.
+            }
+        }
+
+        return '';
+    },
+};

--- a/src/skeleton/rules/page-constructor.ts
+++ b/src/skeleton/rules/page-constructor.ts
@@ -31,7 +31,7 @@ function getValidator() {
             keyword: 'translate',
             type: ['string', 'object', 'array'],
             code: genCode((text) => {
-                if (text.match(/^((-\s)?\s*%%%\d+%%%\s*)+$/gm)) {
+                if (/^%%%\d+%%%$/.test(text)) {
                     return text;
                 }
 
@@ -49,57 +49,60 @@ function getValidator() {
     return validator;
 }
 
+function processBlock(consumer: Consumer, yaml: string, map: Token['map']) {
+    if (!yaml.trim()) {
+        return;
+    }
+
+    let data: unknown;
+    try {
+        data = load(yaml);
+    } catch {
+        // Broken YAML is left in the skeleton as is.
+        return;
+    }
+
+    if (!data || typeof data !== 'object') {
+        return;
+    }
+
+    collected = [];
+    try {
+        getValidator()(data as object);
+    } catch {
+        // Best effort: values collected before the failure are still processed.
+    }
+
+    const strings = collected;
+    collected = [];
+
+    // The schema walks data in its own order, while the consumer
+    // matches strictly forward. Sort values by their position in
+    // the block to keep the cursor monotonic. Values without a
+    // verbatim occurrence (folded scalars) are matched last.
+    const positioned = strings
+        .filter((text) => !text.includes('\n'))
+        .map((text) => {
+            const at = yaml.indexOf(text);
+            return [at === -1 ? Infinity : at, text] as [number, string];
+        })
+        .sort((a, b) => a[0] - b[0]);
+
+    for (const [, text] of positioned) {
+        try {
+            consumer.process(token('text', {content: text}), map);
+        } catch {
+            // The value was not found in the source block
+            // (quoting, escaping). It stays untranslated.
+        }
+    }
+}
+
 export const pageConstructor: Renderer.RenderRuleRecord = {
     page_constructor: function (this: CustomRenderer<Consumer>, tokens: Token[], idx) {
         const {content, map} = tokens[idx];
-        const yaml = Liquid.unescape(content || '');
 
-        if (!yaml.trim()) {
-            return '';
-        }
-
-        let data: unknown;
-        try {
-            data = load(yaml);
-        } catch {
-            // Broken YAML is left in the skeleton as is.
-            return '';
-        }
-
-        if (!data || typeof data !== 'object') {
-            return '';
-        }
-
-        collected = [];
-        try {
-            getValidator()(data as object);
-        } catch {
-            // Best effort: values collected before the failure are still processed.
-        }
-
-        const strings = collected;
-        collected = [];
-
-        // The schema walks data in its own order, while the consumer
-        // matches strictly forward. Sort values by their position in
-        // the block to keep the cursor monotonic. Values without a
-        // verbatim occurrence (folded scalars) are matched last.
-        const positioned = strings
-            .filter((text) => !text.includes('\n'))
-            .map((text) => {
-                const at = yaml.indexOf(text);
-                return [at === -1 ? Infinity : at, text] as [number, string];
-            })
-            .sort((a, b) => a[0] - b[0]);
-
-        for (const [, text] of positioned) {
-            try {
-                this.state.process(token('text', {content: text}), map);
-            } catch {
-                // The value was not found in the source block
-                // (quoting, escaping). It stays untranslated.
-            }
-        }
+        processBlock(this.state, Liquid.unescape(content || ''), map);
 
         return '';
     },

--- a/src/skeleton/rules/page-constructor.ts
+++ b/src/skeleton/rules/page-constructor.ts
@@ -49,6 +49,103 @@ function getValidator() {
     return validator;
 }
 
+type Anchor = {
+    at: number;
+    text: string;
+};
+
+/**
+ * A claimed occurrence must look like a whole YAML scalar, not a fragment
+ * of another value: on its line it may only be preceded by a key separator,
+ * a list dash or the line start (plus an opening quote and indentation).
+ */
+function isScalarStart(yaml: string, index: number): boolean {
+    let i = index - 1;
+    if (yaml[i] === "'" || yaml[i] === '"') {
+        i--;
+    }
+    while (i >= 0 && (yaml[i] === ' ' || yaml[i] === '\t')) {
+        i--;
+    }
+
+    return i < 0 || yaml[i] === ':' || yaml[i] === '-' || yaml[i] === '\n';
+}
+
+/**
+ * The scalar counterpart of `isScalarStart`: after the occurrence (and an
+ * optional closing quote) only a line break, a flow terminator or a comment
+ * may follow. Rejects occurrences that are prefixes of longer values.
+ */
+function isScalarEnd(yaml: string, index: number): boolean {
+    let i = index;
+    if (yaml[i] === "'" || yaml[i] === '"') {
+        i++;
+    }
+    while (i < yaml.length && (yaml[i] === ' ' || yaml[i] === '\t')) {
+        i++;
+    }
+
+    return i >= yaml.length || '\n\r,]}#'.includes(yaml[i]);
+}
+
+/**
+ * Finds the first occurrence of the value that is not inside an already
+ * claimed range and looks like a whole scalar. Returns -1 when the value
+ * has no verbatim occurrence (folded scalars, escaped quoting).
+ */
+function claimOccurrence(yaml: string, text: string, claimed: [number, number][]): number {
+    let from = 0;
+    while (from <= yaml.length - text.length) {
+        const at = yaml.indexOf(text, from);
+        if (at === -1) {
+            return -1;
+        }
+        from = at + 1;
+
+        const end = at + text.length;
+        if (claimed.some(([start, stop]) => at < stop && end > start)) {
+            continue;
+        }
+        if (!isScalarStart(yaml, at) || !isScalarEnd(yaml, end)) {
+            continue;
+        }
+
+        return at;
+    }
+
+    return -1;
+}
+
+/**
+ * Assigns every value its own occurrence in the block. Longer values claim
+ * first, so a value that is a substring of another one (title: 'Product'
+ * next to description: 'Product Pro') cannot steal the longer value's
+ * position and corrupt it. Repeated values claim consecutive occurrences.
+ */
+function claimAnchors(yaml: string, strings: string[]): {anchored: Anchor[]; loose: string[]} {
+    const claimed: [number, number][] = [];
+    const anchored: Anchor[] = [];
+    const loose: string[] = [];
+
+    const byLength = strings
+        .map((text, index) => ({text, index}))
+        .sort((a, b) => b.text.length - a.text.length || a.index - b.index);
+
+    for (const {text} of byLength) {
+        const at = claimOccurrence(yaml, text, claimed);
+        if (at === -1) {
+            loose.push(text);
+        } else {
+            claimed.push([at, at + text.length]);
+            anchored.push({at, text});
+        }
+    }
+
+    anchored.sort((a, b) => a.at - b.at);
+
+    return {anchored, loose};
+}
+
 function processBlock(consumer: Consumer, yaml: string, map: Token['map']) {
     if (!yaml.trim()) {
         return;
@@ -76,24 +173,41 @@ function processBlock(consumer: Consumer, yaml: string, map: Token['map']) {
     const strings = collected;
     collected = [];
 
-    // The schema walks data in its own order, while the consumer
-    // matches strictly forward. Sort values by their position in
-    // the block to keep the cursor monotonic. Values without a
-    // verbatim occurrence (folded scalars) are matched last.
-    const positioned = strings
-        .filter((text) => !text.includes('\n'))
-        .map((text) => {
-            const at = yaml.indexOf(text);
-            return [at === -1 ? Infinity : at, text] as [number, string];
-        })
-        .sort((a, b) => a[0] - b[0]);
+    const {anchored, loose} = claimAnchors(
+        yaml,
+        strings.filter((text) => text.trim() && !text.includes('\n')),
+    );
 
-    for (const [, text] of positioned) {
+    // Anchored values are processed in their textual order (the consumer
+    // matches strictly forward), each within the window of its own line,
+    // so the consumer cannot match a fragment of a neighboring value.
+    // The token map points at the block content, so line offsets inside
+    // the yaml translate directly into document lines.
+    let line = map ? map[0] : 0;
+    let scanned = 0;
+    for (const {at, text} of anchored) {
+        while (scanned < at) {
+            if (yaml[scanned] === '\n') {
+                line++;
+            }
+            scanned++;
+        }
+
+        try {
+            consumer.process(token('text', {content: text}), map ? [line, line] : map);
+        } catch {
+            // The value was not found in the source block. It stays untranslated.
+        }
+    }
+
+    // Values without a verbatim occurrence (folded scalars) are matched
+    // last across the whole block, best effort: the consumer cursor is
+    // already past the anchored values, so only trailing ones can match.
+    for (const text of loose) {
         try {
             consumer.process(token('text', {content: text}), map);
         } catch {
-            // The value was not found in the source block
-            // (quoting, escaping). It stays untranslated.
+            // The value was not found in the source block. It stays untranslated.
         }
     }
 }


### PR DESCRIPTION
Fixes #273

## Problem

The markdown extractor treated `::: page-constructor ... :::` blocks as regular markdown. Whole YAML chunks ended up flattened into translation units where every newline and its indentation is an `<x ctype="lb"/>` placeholder. Any translator that fails to echo the placeholders byte-exactly (every LLM at least some of the time) corrupts the YAML: dedented lines make `yfm build` fail with `YAMLException`, and models regularly refuse to touch the placeholder soup, leaving whole blocks untranslated.

## Fix

A `page-constructor` container directive is registered in the skeleton pipeline. The block content is parsed as YAML and walked with the existing ajv `translate` keyword machinery against `pageConstructorSchemaJson` from `@diplodoc/ajv` (new dependency). Collected translatable values are matched by the consumer directly in the source block (the same way frontmatter meta values are), so:

- units contain only clean translatable strings (`title`, `text`, `description`, ...);
- all YAML structure, formatting and non-translatable values stay in the skeleton byte-exact;
- compose needs no changes - placeholders sit inside the original YAML text.

Fallbacks are conservative: broken YAML, non-object content, values without a verbatim occurrence in the block (literal scalars with newlines) and values the schema does not know are left in the source language instead of risking structure corruption. Folded scalars are matched across source lines and translated.

On the real `ru/project/page-constructor.md` from diplodoc-platform/docs: 0 units with raw YAML (was 8), identity roundtrip `compose(extract(md), {useSource: true}) === md` is byte-exact, and the translated page parses as valid YAML.

## Known limitation

`@diplodoc/ajv` 0.4.1 describes `slider-block` children under `children`, while real documents use `items`, so card contents under `items` are not marked translatable by the schema and stay in the source language. That is a schema gap to fix in `@diplodoc/ajv`; the extractor picks it up automatically once the schema knows the property.